### PR TITLE
Adding ability to easily disable CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.8
+## 10/05/2015
+
+1. [](#improved)
+    * Added ability to easily disable CSS
+
 # v1.0.7
 ## 09/01/2015
 

--- a/recaptchacontact.php
+++ b/recaptchacontact.php
@@ -50,7 +50,8 @@ class   ReCaptchaContactPlugin extends Plugin
 
     public function onTwigSiteVariables() // Esto se procesa después de onPageInitialized
     {
-        if ($this->grav['config']->get('plugins.recaptchacontact.enabled')) {
+        if ($this->grav['config']->get('plugins.recaptchacontact.enabled')
+            && !$this->grav['config']->get('plugins.recaptchacontact.disable_css')) {
             $this->grav['assets']->addCss('plugin://recaptchacontact/assets/css/style.css');
         }
     }

--- a/recaptchacontact.yaml
+++ b/recaptchacontact.yaml
@@ -1,4 +1,5 @@
 enabled: true
 default_lang: en
+disable_css: true
 grecaptcha_sitekey: "your reCAPTCHA site key" # override in your /user/config/plugins/recaptchacontact.yaml
 grecaptcha_secret: "your secret-g-recaptcha-key" # override in your /user/config/plugins/recaptchacontact.yaml and keep it in a non-public repository


### PR DESCRIPTION
While using this plugin for a client, I noticed that there was a very small stylesheet that was limiting the width of the form to 50% and disabling margins. While the template is easy to override, the stylesheet was not as clean to do that with. Adding a very simple conditional allows users to quickly disable the CSS - saving page weight and avoiding a specificity war. 
