### PR TITLE
Added the ability to customize the plugin template more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.9
+## 10/09/2015
+
+1. [](#improved)
+    * Added the ability to customize almost everything in the plugin very easily.
+
 # v1.0.8
 ## 10/05/2015
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You should now have all the plugin files under
 
     /your/site/grav/user/plugins/recaptchacontact
 
->> NOTE: This plugin is a modular component for Grav which requires [Grav](http://github.com/getgrav/grav), the [Error](https://github.com/getgrav/grav-plugin-error) and [Problems](https://github.com/getgrav/grav-plugin-problems) plugins, and a theme to be installed in order to operate. It also requires having at least an outgoing mailserver on your server side (to send the emails) and a [reCAPTCHA API key](www.google.com/recaptcha/) for your site.
+> NOTE: This plugin is a modular component for Grav which requires [Grav](http://github.com/getgrav/grav), the [Error](https://github.com/getgrav/grav-plugin-error) and [Problems](https://github.com/getgrav/grav-plugin-problems) plugins, and a theme to be installed in order to operate. It also requires having at least an outgoing mailserver on your server side (to send the emails) and a [reCAPTCHA API key](www.google.com/recaptcha/) for your site.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ But if you want to overwrite any of the configuration variables (including those
 
 Just use the same structure as in the `languages.yaml`file but use lowercase letters instead of uppercase.
 
+#### Overriding:
+
 If you want to position the form in your template files manually, set `inject_template` to `false` (see above), and add the following to any templates that you want it to display in:
 
     {% include 'partials/recaptchaform.html.twig' with {'page': page, 'recaptchacontact': recaptchacontact} %}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The plugin comes with some sensible default configuration that you can see in th
 ```
 enabled: (true|false)               // Enables or Disables the entire plugin for all pages.
 default_lang: en                    // default_lang in case there is no multilang support in the installation
+disable_css: (false|true)           // Enables or Disables the small stylesheet that provides default styles for the form and messages
+inject_template: (true|false)       // If false, you will need to include the `recaptchaform.html.twig` in your templates
 
 grecaptcha_sitekey: "your reCAPTCHA site key" // override in your /user/config/plugins/recaptchacontact.yaml
 grecaptcha_secret: "secret-g-recaptcha-key" // override in your /user/config/plugins/recaptchacontact.yaml and remember not to keep it in a public repository
@@ -122,6 +124,11 @@ But if you want to overwrite any of the configuration variables (including those
 
 Just use the same structure as in the `languages.yaml`file but use lowercase letters instead of uppercase.
 
+If you want to position the form in your template files manually, set `inject_template` to `false` (see above), and add the following to any templates that you want it to display in:
+
+    {% include 'partials/recaptchaform.html.twig' with {'page': page, 'recaptchacontact': recaptchacontact} %}
+    
+You can also easily override `partials/recaptcha_container.html.twig` to adjust the layout of the HTML surrounding the form. 
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Just use the same structure as in the `languages.yaml`file but use lowercase let
 
 #### Overriding:
 
-If you want to position the form in your template files manually, set `inject_template` to `false` (see above), and add the following to any templates that you want it to display in:
+If you want to position the form in your template files manually, set `inject_template` to `false` [(see above)](#options-in-recaptchacontactyaml), and add the following to any templates that you want it to display in:
 
     {% include 'partials/recaptchaform.html.twig' with {'page': page, 'recaptchacontact': recaptchacontact} %}
     

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,12 +1,35 @@
-.antispam-div { display: none; }
+.antispam-div {
+    display: none;
+}
 
-#contact.container {
+.recaptcha-contact {
     width: 50%;
     margin: 0;
 }
 
-#contact .button {
+.recaptcha-contact .button {
     float: right;
     margin: 5px;
+}
+
+.recaptcha-contact .alert {
+    border: 1px solid #ccc;
+    background-color: #fafafa;
+    padding: 10px;
+}
+
+.recaptcha-contact .alert.success {
+    border-color: #558042;
+    background-color: #F4FBF1;
+}
+
+.recaptcha-contact .alert.error,
+.recaptcha-contact .alert.fail {
+    border-color: #B67272;
+    background-color: #FBF1F1;
+}
+
+.recaptcha-contact .alert p {
+    margin: 0;
 }
 

--- a/recaptchacontact.php
+++ b/recaptchacontact.php
@@ -23,7 +23,7 @@ use Grav\Common\Uri;
 
 class ReCaptchaContactPlugin extends Plugin
 {
-    protected $submissionMessage = [];
+    protected $submissionMessage = array();
 
     public static function getSubscribedEvents()
     {
@@ -67,7 +67,7 @@ class ReCaptchaContactPlugin extends Plugin
 
     public function onPageInitialized()
     {    
-        if ($this->grav['page']->collection() != []){
+        if (!empty($this->grav['page']->collection())){
             $collection = $this->grav['page']->collection();
 
             /** @var $page Page */

--- a/recaptchacontact.php
+++ b/recaptchacontact.php
@@ -85,15 +85,15 @@ class ReCaptchaContactPlugin extends Plugin
     {
         /** @var $twig \Grav\Common\Twig\Twig */
         $twig = $this->grav['twig'];
-        $old_content = $page->content();
-        $template = 'partials/recaptchaform.html.twig';
+        $original_content = $page->content();
+        $template = 'partials/recaptcha_container.html.twig';
 
         $data = [
             'recaptchacontact' => $this->grav['config']->get('plugins.recaptchacontact'),
             'page' => $page
         ];
 
-        $page->content($old_content . $twig->processTemplate($template, $data));
+        $page->content($original_content . $twig->processTemplate($template, $data));
     }
 
     protected function setupRecaptchaContact(Page $page, $collection = false)

--- a/recaptchacontact.php
+++ b/recaptchacontact.php
@@ -19,9 +19,12 @@ namespace Grav\Plugin;
 
 use Grav\Common\Page\Page;
 use Grav\Common\Plugin;
+use Grav\Common\Uri;
 
-class   ReCaptchaContactPlugin extends Plugin
+class ReCaptchaContactPlugin extends Plugin
 {
+    private $submissionMessage = [];
+
     public static function getSubscribedEvents()
     {
         return [
@@ -50,85 +53,93 @@ class   ReCaptchaContactPlugin extends Plugin
 
     public function onTwigSiteVariables() // Esto se procesa después de onPageInitialized
     {
-        if ($this->grav['config']->get('plugins.recaptchacontact.enabled')
-            && !$this->grav['config']->get('plugins.recaptchacontact.disable_css')) {
-            $this->grav['assets']->addCss('plugin://recaptchacontact/assets/css/style.css');
+        $config = $this->grav['config'];
+//        $twigVars = $this->grav['twig']->twig_vars['recaptchacontact'];
+
+        if ($config->get('plugins.recaptchacontact.enabled')) {
+            if (!$this->grav['config']->get('plugins.recaptchacontact.disable_css')) {
+                $this->grav['assets']->addCss('plugin://recaptchacontact/assets/css/style.css');
+            }
+
+            $this->grav['twig']->twig_vars['recaptchacontact'] = $this->grav['config']->get('plugins.recaptchacontact');
+            $this->grav['twig']->twig_vars['recaptchacontact']['message'] = $this->submissionMessage;
         }
     }
-    
+
     public function onPageInitialized()
     {    
         /* Include Modular pages */
-        if ($this->grav['page'] ->collection()!=[]){
+        if ($this->grav['page']->collection() != []){
             $collection = $this->grav['page']->collection();
+
             // Loop over collection of modular pages 
-                foreach ($collection as $page) {
-                    if(isset($page->header()->recaptchacontact)){
-                        $this-> addContactToPage($page);
-                    }
+            foreach ($collection as $page) {
+                if (isset($page->header()->recaptchacontact)){
+                    $this->addContactToPage($page);
                 }
+            }
         } else {
-            $this-> addContactToPage($this->grav['page']);
+            $this->addContactToPage($this->grav['page']);
         }     
     }
 
-    protected function addContactToPage (Page $page)
+    protected function setSubmissionMessage($type, $text)
+    {
+        $this->submissionMessage = [
+            'type' => $type,
+            'text' => $text
+        ];
+    }
+
+    protected function addContactToPage(Page $page)
     {
         $this->mergePluginConfig($page); 
-        $config = $this->grav['config'];
-        $options = $config->get('plugins.recaptchacontact');
+        $options = $this->grav['config']->get('plugins.recaptchacontact');
         
+        if ($options['enabled']) {
+            $uri = $this->grav['uri'];
+
+            if ($uri->param('send') === false) {
+                $this->processFormAction($uri);
+            } else {
+                $this->getMessageFromUrl($uri);
+            }
+        }
+    }
+
+    protected function processFormAction(Uri $uri)
+    {
+        if ($_SERVER['REQUEST_METHOD'] == "POST") {
+            if (false === $this->validateFormData()) {
+                $this->grav->redirect($uri->url . '/send:error');
+            } else {
+                if (false === $this->sendEmail()) {
+                    $this->grav->redirect($uri->url . '/send:fail');
+                } else {
+                    $this->grav->redirect($uri->url . '/send:success');
+                }
+            }
+        }
+    }
+
+    protected function getMessageFromUrl(Uri $uri)
+    {
         $message_success = $this->overwriteConfigVariable('plugins.recaptchacontact.messages.success', 'RECAPTCHACONTACT.MESSAGES.SUCCESS');
         $message_error = $this->overwriteConfigVariable('plugins.recaptchacontact.messages.error', 'RECAPTCHACONTACT.MESSAGES.ERROR');
         $message_fail = $this->overwriteConfigVariable('plugins.recaptchacontact.messages.fail', 'RECAPTCHACONTACT.MESSAGES.FAIL');
 
-        if ($options['enabled']) {
-            $twig   = $this->grav['twig'];
-            $uri    = $this->grav['uri'];
+        switch ($uri->param('send')) {
+            case 'success':
+                $this->setSubmissionMessage('success', $message_success);
+                break;
 
-            if (false === $uri->param('send')) {
-            
-                if ($_SERVER['REQUEST_METHOD'] == "POST") {
-                    if (false === $this->validateFormData()) {
-                        $this->grav->redirect($uri->url . '/send:error');
-                    } else {
-                        if (false === $this->sendEmail()) {
-                            $this->grav->redirect($uri->url . '/send:fail');
-                        } else {
-                            $this->grav->redirect($uri->url . '/send:success');
-                        }
-                    }
-                } else {
-                    
-                    $old_content = $page->content();
+            case 'error':
+                $this->setSubmissionMessage('error', $message_error);
+                break;
 
-                    $template = 'partials/recaptchaform.html.twig';
-                    $data = [
-                      'recaptchacontact' => $options,
-                      'page' => $page
-                    ];
-
-                    $page->content($old_content .$twig->processTemplate($template, $data));
-                }
-            } else {
-              
-                switch ($uri->param('send')) {
-                    case 'success':
-                        $page->content($message_success);
-                    break;
-
-                    case 'error':
-                        $page->content($message_error);
-                    break;
-
-                    case 'fail':
-                        $page->content($message_fail);
-                    break;
-
-                    default:
-                    break;
-                }
-            }
+            case 'fail':
+                $this->setSubmissionMessage('fail', $message_fail);
+                break;
         }
     }
 
@@ -144,10 +155,10 @@ class   ReCaptchaContactPlugin extends Plugin
         
         $grecaptcha = $form_data['g-recaptcha-response'];
         $secretkey = $this->grav['config']->get('plugins.recaptchacontact.grecaptcha_secret');
+
         if (!empty($grecaptcha)) {
            $response=json_decode(file_get_contents("https://www.google.com/recaptcha/api/siteverify?secret=".$secretkey."&response=".$grecaptcha), true);
         }
-
 
         return (empty($name) or empty($message) or empty($email) or $antispam or empty($grecaptcha) or $response['success']==false) ? false : true;
     }
@@ -176,8 +187,7 @@ class   ReCaptchaContactPlugin extends Plugin
     protected function sendEmail()
     {
         $form   = $this->filterFormData($_POST);
-        $options = $this->grav['config']->get('plugins.recaptchacontact');
-        
+
         $recipient  = $this->overwriteConfigVariable('plugins.recaptchacontact.recipient','RECAPTCHACONTACT.RECIPIENT'); 
         $subject    = $this->overwriteConfigVariable('plugins.recaptchacontact.subject','RECAPTCHACONTACT.SUBJECT'); 
         $email_content = "Name: {$form['name']}\n";

--- a/recaptchacontact.yaml
+++ b/recaptchacontact.yaml
@@ -1,6 +1,6 @@
 enabled: true
 default_lang: en
 disable_css: true
-inject_template: true # will only impact simple pages
+inject_template: true # will only impact simple pages; if false, just include the partials/recaptchaform or partials/container template manually
 grecaptcha_sitekey: "your reCAPTCHA site key" # override in your /user/config/plugins/recaptchacontact.yaml
 grecaptcha_secret: "your secret-g-recaptcha-key" # override in your /user/config/plugins/recaptchacontact.yaml and keep it in a non-public repository

--- a/recaptchacontact.yaml
+++ b/recaptchacontact.yaml
@@ -1,6 +1,6 @@
 enabled: true
 default_lang: en
-disable_css: true
+disable_css: false
 inject_template: true # will only impact simple pages; if false, just include the partials/recaptchaform or partials/container template manually
 grecaptcha_sitekey: "your reCAPTCHA site key" # override in your /user/config/plugins/recaptchacontact.yaml
 grecaptcha_secret: "your secret-g-recaptcha-key" # override in your /user/config/plugins/recaptchacontact.yaml and keep it in a non-public repository

--- a/recaptchacontact.yaml
+++ b/recaptchacontact.yaml
@@ -1,5 +1,6 @@
 enabled: true
 default_lang: en
 disable_css: true
+inject_template: true # will only impact simple pages
 grecaptcha_sitekey: "your reCAPTCHA site key" # override in your /user/config/plugins/recaptchacontact.yaml
 grecaptcha_secret: "your secret-g-recaptcha-key" # override in your /user/config/plugins/recaptchacontact.yaml and keep it in a non-public repository

--- a/templates/partials/recaptcha_container.html.twig
+++ b/templates/partials/recaptcha_container.html.twig
@@ -1,0 +1,5 @@
+<div id="contact" class="recaptcha-contact container">
+    <div class="row">
+        {% include 'partials/recaptchaform.html.twig' with {'page': page, 'recaptchacontact': recaptchacontact} %}
+    </div>
+</div>

--- a/templates/partials/recaptcha_message.html.twig
+++ b/templates/partials/recaptcha_message.html.twig
@@ -1,0 +1,3 @@
+<div class="alert {{ message.type }}">
+    <p>{{ message.text }}</p>
+</div>

--- a/templates/partials/recaptchaform.html.twig
+++ b/templates/partials/recaptchaform.html.twig
@@ -45,9 +45,7 @@
             </fieldset>
         </form>
     {% else %}
-        <div class="alert {{ recaptchacontact.message.type }}">
-            <p>{{ recaptchacontact.message.text }}</p>
-        </div>
+        {% include 'partials/recaptcha_message.html.twig' with { 'message': recaptchacontact.message } %}
     {% endif %}
     <script>$.getScript("https://www.google.com/recaptcha/api.js?hl={{ grav.language.getActive ?: recaptchacontact.default_lang }}");</script>
 </div>

--- a/templates/partials/recaptchaform.html.twig
+++ b/templates/partials/recaptchaform.html.twig
@@ -4,8 +4,8 @@
     {% set target_slug = page.slug %}
 {% endif %}
 
-<div id="contact" class="container">
-    <div class="row">
+{{ dump(recaptchacontact) }}
+{% if not recaptchacontact.message %}
        <form class="form-horizontal" action="{{ target_slug }}" method="post" id="recaptchacontact">
           <fieldset>
              <legend class="legend "><h3>{{ recaptchacontact.form_legend ?:'RECAPTCHACONTACT.FORM_LEGEND'|t }}</h3></legend>
@@ -13,34 +13,28 @@
                 {# @todo: you can use to integrate with ajax response #}
                 <div id="recaptchacontact-messages"></div>
 
-                <!-- Name input-->
                 <div class="form-group">
                    <label class="control-label" for="name">{{ recaptchacontact.fields.name.label ?:'RECAPTCHACONTACT.FIELDS.NAME.LABEL'|t }}</label>
                    <input id="name" name="name" type="text" placeholder="{{ recaptchacontact.fields.name.placeholder ?:'RECAPTCHACONTACT.FIELDS.NAME.PLACEHOLDER'|t }}" class="form-control" />
                 </div>
 
-                <!-- Email input-->
                 <div class="form-group">
                    <label class="control-label" for="email">{{ recaptchacontact.fields.email.label ?:'RECAPTCHACONTACT.FIELDS.EMAIL.LABEL'|t }}</label>
                    <input id="email" name="email" type="text" placeholder="{{ recaptchacontact.fields.email.placeholder ?:'RECAPTCHACONTACT.FIELDS.EMAIL.PLACEHOLDER'|t }}" class="form-control" />
                  </div>
 
-                <!-- Message body -->
                 <div class="form-group">
                 <label class="control-label" for="message">{{ recaptchacontact.fields.message.label ?:'RECAPTCHACONTACT.FIELDS.MESSAGE.LABEL'|t }}</label>
                 <textarea class="form-control" id="message" name="message" placeholder="{{ recaptchacontact.fields.message.placeholder ?:'RECAPTCHACONTACT.FIELDS.MESSAGE.PLACEHOLDER'|t }}" rows="5"></textarea>
                 </div>
                 
-                <!-- Recaptcha -->
                 <div class="g-recaptcha" data-sitekey={{ recaptchacontact.grecaptcha_sitekey }}></div>
                 
-                 <!-- Antispam input-->
                  <div class="form-group antispam-div">
                     <label class="control-label" for="antispam">{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.LABEL'|t }}</label>
                     <input id="antispam" name="antispam" type="text" placeholder="{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.PLACEHOLDER'|t }}" class="form-control" />
                  </div>
 
-                 <!-- Form actions -->
                  <div class="form-group">
                     <div class="text-right">
                         <button type="submit" class="button">{{ recaptchacontact.fields.submit.label ?:'RECAPTCHACONTACT.FIELDS.SUBMIT.LABEL'|t }}</button>
@@ -48,7 +42,10 @@
                   </div>
           </fieldset>
        </form>
+{% else %}
+    <div class="alert {{ recaptchacontact.message.type }}">
+        <p>{{ recaptchacontact.message.text }}</p>
     </div>
-</div>
+{% endif %}
 <script>$.getScript("https://www.google.com/recaptcha/api.js?hl={{ grav.language.getActive ?: recaptchacontact.default_lang }}");</script>
 

--- a/templates/partials/recaptchaform.html.twig
+++ b/templates/partials/recaptchaform.html.twig
@@ -4,7 +4,7 @@
     {% set target_slug = page.slug %}
 {% endif %}
 
-<div> {# Twig will render this template as raw HTML without this DIV. #}
+<div> {# Twig or Parsedown will render this template as raw HTML without this DIV. #}
     {% if not recaptchacontact.message %}
         <form class="form-horizontal" action="{{ target_slug }}" method="post" id="recaptchacontact">
             <fieldset>

--- a/templates/partials/recaptchaform.html.twig
+++ b/templates/partials/recaptchaform.html.twig
@@ -1,55 +1,53 @@
-{% if  page.modular == true %}
+{% if page.modular == true %}
      {% set target_slug = page.parent.slug %}
 {% else %}
     {% set target_slug = page.slug %}
 {% endif %}
 
-{{ dump(recaptchacontact) }}
-{{ dump(page) }}
+<div> {# Twig will render this template as raw HTML without this DIV. #}
+    {% if not recaptchacontact.message %}
+        <form class="form-horizontal" action="{{ target_slug }}" method="post" id="recaptchacontact">
+            <fieldset>
+                <h3>
+                    <legend class="legend">{{ recaptchacontact.form_legend ?:'RECAPTCHACONTACT.FORM_LEGEND'|t }}</legend>
+                </h3>
 
-{% if not recaptchacontact.message %}
-    <form class="form-horizontal" action="{{ target_slug }}" method="post" id="recaptchacontact">
-        <fieldset>
-            <h3>
-                <legend class="legend">{{ recaptchacontact.form_legend ?:'RECAPTCHACONTACT.FORM_LEGEND'|t }}</legend>
-            </h3>
+                {# @todo: you can use to integrate with ajax response #}
+                <div id="recaptchacontact-messages"></div>
 
-            {# @todo: you can use to integrate with ajax response #}
-            <div id="recaptchacontact-messages"></div>
-
-            <div class="form-group">
-                <label class="control-label" for="name">{{ recaptchacontact.fields.name.label ?:'RECAPTCHACONTACT.FIELDS.NAME.LABEL'|t }}</label>
-                <input id="name" name="name" type="text" placeholder="{{ recaptchacontact.fields.name.placeholder ?:'RECAPTCHACONTACT.FIELDS.NAME.PLACEHOLDER'|t }}" class="form-control" />
-            </div>
-
-            <div class="form-group">
-                <label class="control-label" for="email">{{ recaptchacontact.fields.email.label ?:'RECAPTCHACONTACT.FIELDS.EMAIL.LABEL'|t }}</label>
-                <input id="email" name="email" type="text" placeholder="{{ recaptchacontact.fields.email.placeholder ?:'RECAPTCHACONTACT.FIELDS.EMAIL.PLACEHOLDER'|t }}" class="form-control" />
-             </div>
-
-            <div class="form-group">
-                <label class="control-label" for="message">{{ recaptchacontact.fields.message.label ?:'RECAPTCHACONTACT.FIELDS.MESSAGE.LABEL'|t }}</label>
-                <textarea class="form-control" id="message" name="message" placeholder="{{ recaptchacontact.fields.message.placeholder ?:'RECAPTCHACONTACT.FIELDS.MESSAGE.PLACEHOLDER'|t }}" rows="5"></textarea>
-            </div>
-
-            <div class="g-recaptcha" data-sitekey={{ recaptchacontact.grecaptcha_sitekey }}></div>
-
-            <div class="form-group antispam-div">
-                <label class="control-label" for="antispam">{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.LABEL'|t }}</label>
-                <input id="antispam" name="antispam" type="text" placeholder="{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.PLACEHOLDER'|t }}" class="form-control" />
-            </div>
-
-            <div class="form-group">
-                <div class="text-right">
-                    <button type="submit" class="button">{{ recaptchacontact.fields.submit.label ?:'RECAPTCHACONTACT.FIELDS.SUBMIT.LABEL'|t }}</button>
+                <div class="form-group">
+                    <label class="control-label" for="name">{{ recaptchacontact.fields.name.label ?:'RECAPTCHACONTACT.FIELDS.NAME.LABEL'|t }}</label>
+                    <input id="name" name="name" type="text" placeholder="{{ recaptchacontact.fields.name.placeholder ?:'RECAPTCHACONTACT.FIELDS.NAME.PLACEHOLDER'|t }}" class="form-control" />
                 </div>
-            </div>
-        </fieldset>
-    </form>
-{% else %}
-    <div class="alert {{ recaptchacontact.message.type }}">
-        <p>{{ recaptchacontact.message.text }}</p>
-    </div>
-{% endif %}
-<script>$.getScript("https://www.google.com/recaptcha/api.js?hl={{ grav.language.getActive ?: recaptchacontact.default_lang }}");</script>
 
+                <div class="form-group">
+                    <label class="control-label" for="email">{{ recaptchacontact.fields.email.label ?:'RECAPTCHACONTACT.FIELDS.EMAIL.LABEL'|t }}</label>
+                    <input id="email" name="email" type="text" placeholder="{{ recaptchacontact.fields.email.placeholder ?:'RECAPTCHACONTACT.FIELDS.EMAIL.PLACEHOLDER'|t }}" class="form-control" />
+                 </div>
+
+                <div class="form-group">
+                    <label class="control-label" for="message">{{ recaptchacontact.fields.message.label ?:'RECAPTCHACONTACT.FIELDS.MESSAGE.LABEL'|t }}</label>
+                    <textarea class="form-control" id="message" name="message" placeholder="{{ recaptchacontact.fields.message.placeholder ?:'RECAPTCHACONTACT.FIELDS.MESSAGE.PLACEHOLDER'|t }}" rows="5"></textarea>
+                </div>
+
+                <div class="g-recaptcha" data-sitekey={{ recaptchacontact.grecaptcha_sitekey }}></div>
+
+                <div class="form-group antispam-div">
+                    <label class="control-label" for="antispam">{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.LABEL'|t }}</label>
+                    <input id="antispam" name="antispam" type="text" placeholder="{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.PLACEHOLDER'|t }}" class="form-control" />
+                </div>
+
+                <div class="form-group">
+                    <div class="text-right">
+                        <button type="submit" class="button">{{ recaptchacontact.fields.submit.label ?:'RECAPTCHACONTACT.FIELDS.SUBMIT.LABEL'|t }}</button>
+                    </div>
+                </div>
+            </fieldset>
+        </form>
+    {% else %}
+        <div class="alert {{ recaptchacontact.message.type }}">
+            <p>{{ recaptchacontact.message.text }}</p>
+        </div>
+    {% endif %}
+    <script>$.getScript("https://www.google.com/recaptcha/api.js?hl={{ grav.language.getActive ?: recaptchacontact.default_lang }}");</script>
+</div>

--- a/templates/partials/recaptchaform.html.twig
+++ b/templates/partials/recaptchaform.html.twig
@@ -5,43 +5,47 @@
 {% endif %}
 
 {{ dump(recaptchacontact) }}
+{{ dump(page) }}
+
 {% if not recaptchacontact.message %}
-       <form class="form-horizontal" action="{{ target_slug }}" method="post" id="recaptchacontact">
-          <fieldset>
-             <legend class="legend "><h3>{{ recaptchacontact.form_legend ?:'RECAPTCHACONTACT.FORM_LEGEND'|t }}</h3></legend>
+    <form class="form-horizontal" action="{{ target_slug }}" method="post" id="recaptchacontact">
+        <fieldset>
+            <h3>
+                <legend class="legend">{{ recaptchacontact.form_legend ?:'RECAPTCHACONTACT.FORM_LEGEND'|t }}</legend>
+            </h3>
 
-                {# @todo: you can use to integrate with ajax response #}
-                <div id="recaptchacontact-messages"></div>
+            {# @todo: you can use to integrate with ajax response #}
+            <div id="recaptchacontact-messages"></div>
 
-                <div class="form-group">
-                   <label class="control-label" for="name">{{ recaptchacontact.fields.name.label ?:'RECAPTCHACONTACT.FIELDS.NAME.LABEL'|t }}</label>
-                   <input id="name" name="name" type="text" placeholder="{{ recaptchacontact.fields.name.placeholder ?:'RECAPTCHACONTACT.FIELDS.NAME.PLACEHOLDER'|t }}" class="form-control" />
-                </div>
+            <div class="form-group">
+                <label class="control-label" for="name">{{ recaptchacontact.fields.name.label ?:'RECAPTCHACONTACT.FIELDS.NAME.LABEL'|t }}</label>
+                <input id="name" name="name" type="text" placeholder="{{ recaptchacontact.fields.name.placeholder ?:'RECAPTCHACONTACT.FIELDS.NAME.PLACEHOLDER'|t }}" class="form-control" />
+            </div>
 
-                <div class="form-group">
-                   <label class="control-label" for="email">{{ recaptchacontact.fields.email.label ?:'RECAPTCHACONTACT.FIELDS.EMAIL.LABEL'|t }}</label>
-                   <input id="email" name="email" type="text" placeholder="{{ recaptchacontact.fields.email.placeholder ?:'RECAPTCHACONTACT.FIELDS.EMAIL.PLACEHOLDER'|t }}" class="form-control" />
-                 </div>
+            <div class="form-group">
+                <label class="control-label" for="email">{{ recaptchacontact.fields.email.label ?:'RECAPTCHACONTACT.FIELDS.EMAIL.LABEL'|t }}</label>
+                <input id="email" name="email" type="text" placeholder="{{ recaptchacontact.fields.email.placeholder ?:'RECAPTCHACONTACT.FIELDS.EMAIL.PLACEHOLDER'|t }}" class="form-control" />
+             </div>
 
-                <div class="form-group">
+            <div class="form-group">
                 <label class="control-label" for="message">{{ recaptchacontact.fields.message.label ?:'RECAPTCHACONTACT.FIELDS.MESSAGE.LABEL'|t }}</label>
                 <textarea class="form-control" id="message" name="message" placeholder="{{ recaptchacontact.fields.message.placeholder ?:'RECAPTCHACONTACT.FIELDS.MESSAGE.PLACEHOLDER'|t }}" rows="5"></textarea>
-                </div>
-                
-                <div class="g-recaptcha" data-sitekey={{ recaptchacontact.grecaptcha_sitekey }}></div>
-                
-                 <div class="form-group antispam-div">
-                    <label class="control-label" for="antispam">{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.LABEL'|t }}</label>
-                    <input id="antispam" name="antispam" type="text" placeholder="{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.PLACEHOLDER'|t }}" class="form-control" />
-                 </div>
+            </div>
 
-                 <div class="form-group">
-                    <div class="text-right">
-                        <button type="submit" class="button">{{ recaptchacontact.fields.submit.label ?:'RECAPTCHACONTACT.FIELDS.SUBMIT.LABEL'|t }}</button>
-                     </div>
-                  </div>
-          </fieldset>
-       </form>
+            <div class="g-recaptcha" data-sitekey={{ recaptchacontact.grecaptcha_sitekey }}></div>
+
+            <div class="form-group antispam-div">
+                <label class="control-label" for="antispam">{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.LABEL'|t }}</label>
+                <input id="antispam" name="antispam" type="text" placeholder="{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.PLACEHOLDER'|t }}" class="form-control" />
+            </div>
+
+            <div class="form-group">
+                <div class="text-right">
+                    <button type="submit" class="button">{{ recaptchacontact.fields.submit.label ?:'RECAPTCHACONTACT.FIELDS.SUBMIT.LABEL'|t }}</button>
+                </div>
+            </div>
+        </fieldset>
+    </form>
 {% else %}
     <div class="alert {{ recaptchacontact.message.type }}">
         <p>{{ recaptchacontact.message.text }}</p>


### PR DESCRIPTION
As I was working with the plugin, I noticed that it duplicated a `<section />` tag which I thought was unusual. I looked into the code and found that the plugin was appending the template onto the page's current content. That made sense because I had noticed that I didn't have to add any `include` statements in my theme's templates. However, with that, it seems to be a non-standard and non-adjustable way of adding the form. 

I developed the module to be backwards compatible, while adding an option to disable the default function of appending the template. As a result, users can now easily disable that and add their own `include` tag in their templates. I believe that this is a superior way to do it because it allows easier and faster customization and seems to be more in line with what other plugins do (like Pagination and such). 

Also, I split out the actual form into it's own file, separate from the markup that surrounded it. The advantage of doing it this way is that users don't have to override the entire form to make a change to the form's container. I moved away from using an ID to style the form. An ID is one of the "strongest" selectors and as a result it is hard to override. I understand that it is actually considered best practice to never use an ID as a CSS selector (obviously JS is a good use for IDs). Using a custom class allows developers to easily override the styles without having to completely disable them. 

I split the form messages out into their own method and property. This allows them to be globally accessible (within the class's methods). That makes it very easy to pass them into Twig and let the template handle the rest. The clear benefit of this is being able to style all of the messages very simply. By having the messages in their own file, developers can easily override them if they want to.

I developed on the `dev` branch, but checked out a new branch to allow greater control of what you merge, if you like these changes, or not. Please feel free to ping me with any questions or comments: I'm more than happy to collaborate more on this or explain any of the code that I changed. I really like this plugin and hope these changes will encourage more users.

I did not test this with PHP 5.3, but am not aware of anything that would cause it to break. I also wasn't sure what template it is designed to drop into. As a result, I didn't minimize any of the markup that surrounded the form. Again, if I missed something, please let me know and I will work on it.

---

**Possible Future Improvements**
The one other thing that I thought about changing was the `mail()` function and moving to Twig and SwiftMailer for that.
