### PR TITLE
Fixed a bug that was causing translations to be pulled in as an array

### DIFF
--- a/recaptchacontact.php
+++ b/recaptchacontact.php
@@ -81,6 +81,11 @@ class ReCaptchaContactPlugin extends Plugin
         }
     }
 
+    /**
+     * Automatically add the contact form to the Page being loaded
+     *
+     * @param \Grav\Common\Page\Page $page
+     */
     protected function injectTemplate(Page $page)
     {
         /** @var $twig \Grav\Common\Twig\Twig */
@@ -101,6 +106,12 @@ class ReCaptchaContactPlugin extends Plugin
         $page->content('<div>' . $original_content . $twig->processTemplate($template, $data) . '</div>');
     }
 
+    /**
+     * Setup the Recaptcha Contact form
+     *
+     * @param \Grav\Common\Page\Page $page
+     * @param bool|false             $collection
+     */
     protected function setupRecaptchaContact(Page $page, $collection = false)
     {
         $this->mergePluginConfig($page); 
@@ -121,6 +132,11 @@ class ReCaptchaContactPlugin extends Plugin
         }
     }
 
+    /**
+     * Handle the Form Process
+     *
+     * @param \Grav\Common\Uri $uri
+     */
     protected function processFormAction(Uri $uri)
     {
         if ($_SERVER['REQUEST_METHOD'] == "POST") {
@@ -136,6 +152,10 @@ class ReCaptchaContactPlugin extends Plugin
         }
     }
 
+    /**
+     * @param $type: Type of message to be displayed
+     * @param $text: Text of message for user
+     */
     protected function setSubmissionMessage($type, $text)
     {
         $this->submissionMessage = [
@@ -144,6 +164,11 @@ class ReCaptchaContactPlugin extends Plugin
         ];
     }
 
+    /**
+     * Build a message depending on the URL that the form redirected to
+     *
+     * @param \Grav\Common\Uri $uri
+     */
     protected function getMessageFromUrl(Uri $uri)
     {
         $message_success = $this->overwriteConfigVariable('plugins.recaptchacontact.messages.success', 'RECAPTCHACONTACT.MESSAGES.SUCCESS');
@@ -165,6 +190,11 @@ class ReCaptchaContactPlugin extends Plugin
         }
     }
 
+    /**
+     * Make sure that the form is valid
+     *
+     * @return bool
+     */
     protected function validateFormData()
     {
         $form_data = $this->filterFormData($_POST);
@@ -185,6 +215,13 @@ class ReCaptchaContactPlugin extends Plugin
         return (empty($name) or empty($message) or empty($email) or $antispam or empty($grecaptcha) or $response['success']==false) ? false : true;
     }
 
+    /**
+     * Clean up and abstract form data
+     *
+     * @param $form
+     *
+     * @return array
+     */
     protected function filterFormData($form)
     {
         $defaults = [
@@ -206,6 +243,11 @@ class ReCaptchaContactPlugin extends Plugin
         ];
     }
 
+    /**
+     * Send the email
+     *
+     * @return bool: returns true if email was sent | return false if it failed to send
+     */
     protected function sendEmail()
     {
         $form   = $this->filterFormData($_POST);
@@ -239,7 +281,7 @@ class ReCaptchaContactPlugin extends Plugin
     private function overwriteConfigVariable($pageconfigvar, $langconfigvar)
     {
         $language = $this->grav['language']; 
-        return $this->grav['config']->get($pageconfigvar) ?: $language->translate([$langconfigvar], null, true);
+        return $this->grav['config']->get($pageconfigvar) ?: $language->translate([$langconfigvar], null, false);
     }
     
 }

--- a/recaptchacontact.php
+++ b/recaptchacontact.php
@@ -281,7 +281,7 @@ class ReCaptchaContactPlugin extends Plugin
     private function overwriteConfigVariable($pageconfigvar, $langconfigvar)
     {
         $language = $this->grav['language']; 
-        return $this->grav['config']->get($pageconfigvar) ?: $language->translate([$langconfigvar], null, false);
+        return $this->grav['config']->get($pageconfigvar) ?: $language->translate([$langconfigvar]);
     }
     
 }


### PR DESCRIPTION
The main change is at the very bottom where the parameter was causing the `translate` method to return an array. As a result, there was a consistent Exception being thrown for the array to string conversion. I'm not sure if this worked before but doesn't now due to a change in Grav core or what. 

Basically it was returning an array like this:

```
$translation = array(
    [0] => "Error message"
    [1] => "Error message"
)
```
