### PR TITLE
Scroll anchor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v2.1.0
+## 1/7/2017
+
+1. [](#new)
+    * Added option to have a data-callback for the Google Recaptcha
+    
+   [](#improved)
+    * Added scroll anchor so the page scrolls to the message when there is one.
+
 # v2.0.1
 ## 10/11/2016
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: reCAPTCHA Contact
-version: 2.0.2
+version: 2.1.0
 description: "This plugin adds contact form features for sending email with google reCAPTCHA 2.0 validation."
 icon: paper-plane-o
 author:

--- a/recaptchacontact.php
+++ b/recaptchacontact.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * reCAPTCHA Contact v2.0.2
+ * reCAPTCHA Contact v2.1.0
  *
  * This plugin adds contact form features for sending email with
  * google reCAPTCHA 2.0  validation.
@@ -8,10 +8,10 @@
  * Licensed under the MIT license, see LICENSE.
  *
  * @package     recaptchacontact
- * @version     2.0.1
+ * @version     2.1.0
  * @link        <https://github.com/aradianoff/recaptchacontact>
  * @author      aRadianOff - Inés Naya <inesnaya@aradianoff.com>
- * @copyright   2015, Inés Naya - aRadianOff
+ * @copyright   2017, Inés Naya - aRadianOff
  * @license     <http://opensource.org/licenses/MIT>        MIT
  */
 

--- a/recaptchacontact.yaml
+++ b/recaptchacontact.yaml
@@ -4,3 +4,4 @@ disable_css: false
 inject_template: true # if false, include the partials/recaptchaform or partials/container template manually
 grecaptcha_sitekey: "your reCAPTCHA site key" # override in your /user/config/plugins/recaptchacontact.yaml
 grecaptcha_secret: "your secret-g-recaptcha-key" # override in your /user/config/plugins/recaptchacontact.yaml and keep it in a non-public repository
+grecaptcha_callback: false # advanced usage only. @see https://developers.google.com/recaptcha/docs/verify

--- a/templates/partials/recaptcha_js.html.twig
+++ b/templates/partials/recaptcha_js.html.twig
@@ -1,0 +1,4 @@
+<script type="text/javascript">
+    location.href = "#";
+    location.href = "#contact-form";
+</script>

--- a/templates/partials/recaptchaform.html.twig
+++ b/templates/partials/recaptchaform.html.twig
@@ -1,10 +1,10 @@
 {% if page.modular == true %}
-     {% set target_slug = page.parent.slug %}
+    {% set target_slug = page.parent.slug %}
 {% else %}
     {% set target_slug = page.slug %}
 {% endif %}
 
-<div> {# Twig or Parsedown will render this template as raw HTML without this DIV. #}
+<div class="recaptcha-form-container" id="contact-form"> {# Twig or Parsedown will render this template as raw HTML without this DIV. #}
     {% if recaptchacontact.message %}
         {% include 'partials/recaptcha_message.html.twig' with { 'message': recaptchacontact.message } %}
     {% endif %}
@@ -25,14 +25,14 @@
             <div class="recaptcha-form-group form-group">
                 <label class="recaptcha-label control-label" for="email">{{ recaptchacontact.fields.email.label ?:'RECAPTCHACONTACT.FIELDS.EMAIL.LABEL'|t }}</label>
                 <input id="email" name="email" type="text" placeholder="{{ recaptchacontact.fields.email.placeholder ?:'RECAPTCHACONTACT.FIELDS.EMAIL.PLACEHOLDER'|t }}" class="recaptcha-field form-control" value="{{ recaptchacontact.session.email }}"/>
-             </div>
+            </div>
 
             <div class="recaptcha-form-group form-group">
                 <label class="recaptcha-label control-label" for="message">{{ recaptchacontact.fields.message.label ?:'RECAPTCHACONTACT.FIELDS.MESSAGE.LABEL'|t }}</label>
                 <textarea class="recaptcha-textarea form-control" id="message" name="message" placeholder="{{ recaptchacontact.fields.message.placeholder ?:'RECAPTCHACONTACT.FIELDS.MESSAGE.PLACEHOLDER'|t }}" rows="5">{{ recaptchacontact.session.message }}</textarea>
             </div>
 
-            <div class="g-recaptcha" data-sitekey={{ recaptchacontact.grecaptcha_sitekey }}></div>
+            <div class="g-recaptcha" data-sitekey={{ recaptchacontact.grecaptcha_sitekey }}{% if recaptchacontact.grecaptcha_callback %} data-callback="{{ recaptchacontact.grecaptcha_callback }}"{% endif %}></div>
 
             <div class="recaptcha-hidden form-group antispam-div">
                 <label class="control-label" for="antispam">{{ 'RECAPTCHACONTACT.FIELDS.ANTISPAM.LABEL'|t }}</label>
@@ -46,5 +46,8 @@
             </div>
         </fieldset>
     </form>
-    <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl={{ grav.language.getActive ?: recaptchacontact.default_lang }}" async></script>
+    <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl={{ grav.language.getActive ?: recaptchacontact.default_lang }}" defer></script>
+    {% if recaptchacontact.message %}
+        {% include 'partials/recaptcha_js.html.twig' %}
+    {% endif %}
 </div>


### PR DESCRIPTION
The main purpose of this pull request is to scroll the page to the contact form when a message is displayed. In using this plugin, my co-worker noticed that the page does not scroll down to the message if it is a ways down the page. This should resolve the problem.

It also adds a data-callback option per @cocodrino recommendation in #33.

At some point, I'd like to add an AJAX submission option, but this should resolve the immediate need.